### PR TITLE
Added alert for CollectionFS.

### DIFF
--- a/data/alerts.json
+++ b/data/alerts.json
@@ -64,5 +64,21 @@
                 }
             ]
         }
+    ],
+    "cfs:standard-packages": [
+        {
+            "range": "*",
+            "alert": "Manipulating an uploaded image that has been renamed to a different filetype (e.g. a Quicktime movie renamed as a JPG file) and/or trying to manipulate bad/corrupt images can cause your Meteor server to crash.",
+            "links": [
+                {
+                    "name": "Github Issue 1",
+                    "url": "https://github.com/CollectionFS/Meteor-CollectionFS/issues/550"
+                },
+                {
+                    "name": "Github Issue 2 with Work-Around",
+                    "url": "https://github.com/CollectionFS/Meteor-CollectionFS/issues/227"
+                },
+            ]
+        }
     ]
 }


### PR DESCRIPTION
I wanted to add this because a lot of people still use CollectionFS and S3 or gridFS to upload files (even though Slingshot seems to picking up a lot of traction).  This is worthwhile because the server will actually crash because of an uncaught exception when trying to manipulate a bad image and/or a file that's not an image (a file maliciously renamed to something else).  So this is critically important.

No fix has been submitted so I marked the problem for all versions.
