### PR TITLE
Fix for Windows process.env.PWD

### DIFF
--- a/lib/package-scan.js
+++ b/lib/package-scan.js
@@ -56,7 +56,12 @@ Meteor.startup(function() {
             return {};
         }
 
-        var path = process.env.PWD + '/.meteor/versions';
+        if (process.env.PWD) {
+          var path = process.env.PWD + '/.meteor/versions';
+        } else {
+          var path = process.cwd().split('.meteor')[0] + '.meteor/versions';
+        }
+        
         readline.createInterface({
             input: fs.createReadStream(path),
             output: process.stdout,


### PR DESCRIPTION
`process.env.PWD` does not exist on Windows. Instead, use `process.cwd()` for current working directory and appropriately append version file after.